### PR TITLE
Linux fixes

### DIFF
--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/OcraftApiConfig.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/OcraftApiConfig.java
@@ -53,6 +53,7 @@ public final class OcraftApiConfig {
     public static final String GAME_WINDOW_MODE = GAME_WINDOW + ".mode";
     public static final String GAME_CLI = GAME + ".cli";
     public static final String GAME_CLI_VERBOSE = GAME_CLI + ".verbose";
+    public static final String GAME_CLI_NEEDS_SUPPORT_DIR = GAME_CLI + ".needsSupportDir";
     public static final String GAME_CLI_TEMP_DIR = GAME_CLI + ".tempDir";
     public static final String GAME_CLI_DATA_DIR = GAME_CLI + ".dataDir";
     public static final String GAME_CLI_OS_MESA_PATH = GAME_CLI + ".osmesapath";

--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
@@ -196,7 +196,10 @@ public final class ExecutableParser {
     private static Function<Path, String> toNewestBaseBuild(String exeFile) {
         return versionPath -> {
             try (Stream<Path> builds = Files.list(
-                    ofNullable(versionPath).filter(Files::exists).orElseThrow(required("version directory")))) {
+                    ofNullable(versionPath)
+                            .filter(Files::exists)
+                            .filter(file -> file.getFileName().toString().startsWith(BUILD_PREFIX))
+                            .orElseThrow(required("version directory")))) {
                 return builds.min(reverseOrder())
                         .filter(path -> Files.exists(path.resolve(exeFile)))
                         .map(Path::getFileName)

--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
@@ -198,8 +198,9 @@ public final class ExecutableParser {
             try (Stream<Path> builds = Files.list(
                     ofNullable(versionPath)
                             .filter(Files::exists)
-                            .filter(file -> file.getFileName().toString().startsWith(BUILD_PREFIX))
-                            .orElseThrow(required("version directory")))) {
+                            .orElseThrow(required("version directory")))
+                    .filter(file -> file.getFileName().toString().startsWith(BUILD_PREFIX))
+            ) {
                 return builds.min(reverseOrder())
                         .filter(path -> Files.exists(path.resolve(exeFile)))
                         .map(Path::getFileName)

--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
@@ -140,6 +140,11 @@ public class S2Controller extends DefaultSubscriber<Response> {
             return this;
         }
 
+        public Builder needsSupportDir(Boolean value) {
+            if (isSet(value)) builderConfig.put(GAME_CLI_NEEDS_SUPPORT_DIR, String.valueOf(value));
+            return this;
+        }
+
         public Builder withTmpDir(Path tmpDir) {
             if (isSet(tmpDir)) builderConfig.put(GAME_CLI_TEMP_DIR, tmpDir.toString());
             return this;
@@ -229,7 +234,8 @@ public class S2Controller extends DefaultSubscriber<Response> {
 
             s2Process = new ProcessBuilder(args)
                     .redirectErrorStream(true)
-                    .directory(gameRoot.resolve(getSupportDirPath()).toFile())
+                    .directory(cfg.hasPath(GAME_CLI_NEEDS_SUPPORT_DIR) && cfg.getBoolean(GAME_CLI_NEEDS_SUPPORT_DIR)
+                            ? gameRoot.resolve(getSupportDirPath()).toFile() : null)
                     .start();
 
             log.info("Launched SC2 ({}), PID: {}", exeFile, s2Process.pid());

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
@@ -334,6 +334,12 @@ public class S2Coordinator {
         }
 
         @Override
+        public SettingsSyntax setNeedsSupportDir(Boolean value) {
+            if (isSet(value)) processSettings.setNeedsSupportDir(value);
+            return this;
+        }
+
+        @Override
         public SettingsSyntax setTraced(Boolean value) {
             if (isSet(value)) processSettings.setTraced(value);
             return this;

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
@@ -210,7 +210,7 @@ class ControlInterfaceImpl implements ControlInterface {
                 .withOsMesaPath(processSettings.getOsMesaPath())
                 .verbose(processSettings.getVerbose())
                 .needsSupportDir(processSettings.getNeedsSupportDir())
-                .launch();
+                .launch().untilReady();
     }
 
     // test purposes only

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
@@ -209,6 +209,7 @@ class ControlInterfaceImpl implements ControlInterface {
                 .withEglPath(processSettings.getEglPath())
                 .withOsMesaPath(processSettings.getOsMesaPath())
                 .verbose(processSettings.getVerbose())
+                .needsSupportDir(processSettings.getNeedsSupportDir())
                 .launch();
     }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/setting/ProcessSettings.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/setting/ProcessSettings.java
@@ -30,6 +30,7 @@ import com.github.ocraft.s2client.api.controller.PortSetup;
 import com.github.ocraft.s2client.bot.OcraftBotConfig;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import static com.github.ocraft.s2client.protocol.Preconditions.isSet;
 
@@ -51,6 +52,7 @@ public class ProcessSettings {
     private Integer windowY;
     private Boolean withGameController;
     private Boolean verbose;
+    private Boolean needsSupportDir;
     private Path tmpDir;
     private Path dataDir;
     private Path osMesaPath;
@@ -202,6 +204,15 @@ public class ProcessSettings {
         return verbose;
     }
 
+    public ProcessSettings setNeedsSupportDir(Boolean needsSupportDir) {
+        this.needsSupportDir = needsSupportDir;
+        return this;
+    }
+
+    public Boolean getNeedsSupportDir() {
+        return needsSupportDir;
+    }
+
     public ProcessSettings setTmpDir(Path tmpDir) {
         this.tmpDir = tmpDir;
         return this;
@@ -311,6 +322,7 @@ public class ProcessSettings {
         if (withGameController != null ? !withGameController.equals(that.withGameController) : that.withGameController != null)
             return false;
         if (verbose != null ? !verbose.equals(that.verbose) : that.verbose != null) return false;
+        if (!Objects.equals(needsSupportDir, that.needsSupportDir)) return false;
         if (tmpDir != null ? !tmpDir.equals(that.tmpDir) : that.tmpDir != null) return false;
         if (dataDir != null ? !dataDir.equals(that.dataDir) : that.dataDir != null) return false;
         if (osMesaPath != null ? !osMesaPath.equals(that.osMesaPath) : that.osMesaPath != null) return false;
@@ -341,6 +353,7 @@ public class ProcessSettings {
         result = 31 * result + (windowY != null ? windowY.hashCode() : 0);
         result = 31 * result + (withGameController != null ? withGameController.hashCode() : 0);
         result = 31 * result + (verbose != null ? verbose.hashCode() : 0);
+        result = 31 * result + (needsSupportDir != null ? needsSupportDir.hashCode() : 0);
         result = 31 * result + (tmpDir != null ? tmpDir.hashCode() : 0);
         result = 31 * result + (dataDir != null ? dataDir.hashCode() : 0);
         result = 31 * result + (osMesaPath != null ? osMesaPath.hashCode() : 0);
@@ -373,6 +386,7 @@ public class ProcessSettings {
                 ", windowY=" + windowY +
                 ", withGameController=" + withGameController +
                 ", verbose=" + verbose +
+                ", needsSupportDir=" + needsSupportDir +
                 ", tmpDir=" + tmpDir +
                 ", dataDir=" + dataDir +
                 ", osMesaPath=" + osMesaPath +

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/syntax/SettingsSyntax.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/syntax/SettingsSyntax.java
@@ -153,6 +153,13 @@ public interface SettingsSyntax extends GameParticipantSyntax, ReplaySyntax {
     SettingsSyntax setVerbose(Boolean value);
 
     /**
+     * By default the game is started from inside a support directory containing some needed libraries.
+     * Set to {@code false} when working with the
+     * <a href="https://github.com/Blizzard/s2client-proto#downloads">Linux packages</a>.
+     */
+    SettingsSyntax setNeedsSupportDir(Boolean value);
+
+    /**
      * Enables logging on client of all protocol requests/responses to com.github.ocraft.s2client.api.log.DataFlowTracer
      * logger on level TRACE (JSON format).
      */


### PR DESCRIPTION
This pull request contains fixes for the problems mentioned in #9 and #10.

In particular, the changes are:
- when determining the latest build, only consider subdirectories of the versions directory that start with `BUILD_PREFIX`
- new option for not using the support directory when launching starcraft
- after a starcraft instance is launched via the `ControllerInterface`, wait until the game is ready
- the existing method `reachTheGame()` now contains a fix for a bug that caused it to not wait between retries when the starcraft instance had not yet opened its socket

I tested these changes with the Linux packages for version 4.7.1 on a version of ocraft I backported to that protocol version. Configuring with `S2Coordinator.setup()` and launching with `launchStarcraft()` worked for both, singleplayer and multiplayer games.