### PR TITLE
to handle the custom built balance-patched maps for linux

### DIFF
--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
@@ -36,6 +36,7 @@ import com.github.ocraft.s2client.protocol.game.GameStatus;
 import com.github.ocraft.s2client.protocol.request.Request;
 import com.github.ocraft.s2client.protocol.request.Requests;
 import com.github.ocraft.s2client.protocol.response.Response;
+import com.github.ocraft.s2client.protocol.response.ResponseGameInfo;
 import com.github.ocraft.s2client.protocol.response.ResponsePing;
 import com.github.ocraft.s2client.protocol.response.ResponseType;
 import io.reactivex.Maybe;
@@ -105,12 +106,20 @@ class ProtoInterfaceImpl implements ProtoInterface {
                     .start()
                     .untilReady();
 
+
+            //checks if map name ends in a version number eg "Death Aura 5.0.6"
+            boolean isUpdatedLinuxMap = waitForResponse(sendRequest(Requests.gameInfo()))
+                    .flatMap(response -> response.as(ResponseGameInfo.class))
+                    .map(responseGameInfo -> responseGameInfo.getMapName().matches("^.*\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}$"))
+                    .orElse(false);
+
             waitForResponse(sendRequest(Requests.ping()))
                     .flatMap(response -> response.as(ResponsePing.class))
                     .ifPresentOrElse(ping -> {
                         this.dataVersion = ping.getDataVersion();
                         this.baseBuild = ping.getBaseBuild();
-                        Units.remapForBuild(this.baseBuild);
+                        if (isUpdatedLinuxMap) Units.remapForBuild(Integer.MAX_VALUE); //remap to latest build
+                        else Units.remapForBuild(this.baseBuild);
                     }, () -> {
                         throw new IllegalStateException("ping failed");
                     });


### PR DESCRIPTION
Due to Blizzard dropped support for linux (and the various bugs in windows), custom maps have had to be created to apply the latest balance patches.  More info here: https://aiarena.net/wiki/ids-50-maps-410-linux-version/  

These maps run on 4.10, but mimic the latest patch including ids.  They can be recognized by their map names which end in the version number eg. "Death Aura 5.0.6"

My change calls remapForBuild() with the latest build if one of these maps is being played.

Some important notes as I'm not too familiar with ocraft:
-I'm unsure if the map name is already available somewhere, so I don't know if this waitForResponse is necessary to get it
-I wasn't able to get ocraft running locally so **this change is untested**

Another option would be to allow the bots to remap the ids, leaving it outside of ocraft, but currently only remapForBuild() is public and it won't work as is, calling it when the bot starts.