### PR TITLE
Revert "to handle the custom built balance-patched maps for linux"

### DIFF
--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
@@ -36,7 +36,6 @@ import com.github.ocraft.s2client.protocol.game.GameStatus;
 import com.github.ocraft.s2client.protocol.request.Request;
 import com.github.ocraft.s2client.protocol.request.Requests;
 import com.github.ocraft.s2client.protocol.response.Response;
-import com.github.ocraft.s2client.protocol.response.ResponseGameInfo;
 import com.github.ocraft.s2client.protocol.response.ResponsePing;
 import com.github.ocraft.s2client.protocol.response.ResponseType;
 import io.reactivex.Maybe;
@@ -106,20 +105,12 @@ class ProtoInterfaceImpl implements ProtoInterface {
                     .start()
                     .untilReady();
 
-
-            //checks if map name ends in a version number eg "Death Aura 5.0.6"
-            boolean isUpdatedLinuxMap = waitForResponse(sendRequest(Requests.gameInfo()))
-                    .flatMap(response -> response.as(ResponseGameInfo.class))
-                    .map(responseGameInfo -> responseGameInfo.getMapName().matches("^.*\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}$"))
-                    .orElse(false);
-
             waitForResponse(sendRequest(Requests.ping()))
                     .flatMap(response -> response.as(ResponsePing.class))
                     .ifPresentOrElse(ping -> {
                         this.dataVersion = ping.getDataVersion();
                         this.baseBuild = ping.getBaseBuild();
-                        if (isUpdatedLinuxMap) Units.remapForBuild(Integer.MAX_VALUE); //remap to latest build
-                        else Units.remapForBuild(this.baseBuild);
+                        Units.remapForBuild(this.baseBuild);
                     }, () -> {
                         throw new IllegalStateException("ping failed");
                     });


### PR DESCRIPTION
Reverts ocraft/ocraft-s2client#45

It appears waitForResponse(sendRequest(Requests.gameInfo())) on line111 not only failed to retrieve the map name, but it also caused observation().getGameInfo() to never get populated.  I don't understand this api well enough to fix this.  Perhaps you can edit this line of code to get the map name @ocraft 