### PR TITLE
Upgrade to Java 17, fix multiplayer games

### DIFF
--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
@@ -110,7 +110,12 @@ public class S2Coordinator {
         replaySettings = builder.replaySettings;
         useGeneralizedAbilityId = builder.useGeneralizedAbilityId;
 
-        if (processSettings.isLadderGame() && !builder.ladderSettings.getComputerOpponent()) {
+        if (builder.multiplayerOptions.isPresent()) {
+            if (processSettings.isLadderGame()) {
+                log.warn("Multiplayer options were provided, which supercedes the isLadderGame.");
+            }
+            builder.multiplayerOptions.ifPresent(gameSettings::setMultiplayerOptions);
+        } else if (processSettings.isLadderGame() && !builder.ladderSettings.getComputerOpponent()) {
             setupPorts(agents.size() + 1, () -> processSettings.getPortSetup().fetchPort(), false);
         } else {
             setupPorts(agents.size(), () -> processSettings.getPortSetup().fetchPort(), true);
@@ -168,6 +173,7 @@ public class S2Coordinator {
         private GameSettings gameSettings = new GameSettings();
         private CliSettings cliSettings = new CliSettings();
         private LadderSettings ladderSettings = new LadderSettings();
+        private Optional<MultiplayerOptions> multiplayerOptions = Optional.empty();
 
         private SpatialCameraSetup featureLayerSettings;
         private SpatialCameraSetup renderSettings;
@@ -441,6 +447,12 @@ public class S2Coordinator {
         @Override
         public SettingsSyntax loadReplayList(Path path) throws IOException {
             if (isSet(path)) replaySettings.loadReplayList(path);
+            return this;
+        }
+
+        @Override
+        public SettingsSyntax setMultiplayerOptions(MultiplayerOptions multiplayerOptions) {
+            if (isSet(multiplayerOptions)) this.multiplayerOptions = Optional.of(multiplayerOptions);
             return this;
         }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
@@ -127,6 +127,17 @@ public class S2Coordinator {
      * @param checkSingle    Checks if the game is a single player or multiplayer game
      */
     public void setupPorts(int numberOfAgents, Supplier<Integer> portStart, boolean checkSingle) {
+        withPorts(numberOfAgents, portStart, checkSingle);
+    }
+
+    /**
+     * Sets up the sc2 game ports to use
+     *
+     * @param numberOfAgents Number of agents in the game
+     * @param portStart      Starting port number
+     * @param checkSingle    Checks if the game is a single player or multiplayer game
+     */
+    public S2Coordinator withPorts(int numberOfAgents, Supplier<Integer> portStart, boolean checkSingle) {
         int bots;
         if (checkSingle) {
             bots = (int) gameSettings.getPlayerSettings().stream()
@@ -139,6 +150,7 @@ public class S2Coordinator {
             gameSettings.setMultiplayerOptions(multiplayerSetupFor(portStart.get(), bots));
             log.info("Setting multiplayer options: {}", gameSettings.getMultiplayerOptions());
         }
+        return this;
     }
 
     public static SettingsSyntax setup() {
@@ -436,6 +448,18 @@ public class S2Coordinator {
         public S2Coordinator launchStarcraft() {
             try {
                 processSettings.setWithGameController(true);
+                return new S2Coordinator(this);
+            } catch (Exception e) {
+                printHelp();
+                throw e;
+            }
+        }
+
+        @Override
+        public S2Coordinator launchStarcraft(Integer port) {
+            try {
+                processSettings.setWithGameController(true);
+                processSettings.setPortStart(port);
                 return new S2Coordinator(this);
             } catch (Exception e) {
                 printHelp();
@@ -1031,6 +1055,10 @@ public class S2Coordinator {
     public void quit() {
         agents.forEach(agent -> agent.control().quit());
         replayObservers.forEach(replayObserver -> replayObserver.control().quit());
+    }
+
+    public static PlayerSettings createParticipant(Race race) {
+        return PlayerSettings.participant(race);
     }
 
     public static PlayerSettings createParticipant(Race race, S2Agent bot) {

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/setting/PlayerSettings.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/setting/PlayerSettings.java
@@ -107,6 +107,17 @@ public final class PlayerSettings {
                 aiBuild);
     }
 
+    public static PlayerSettings participant(Race race) {
+        require("race", race);
+        return new PlayerSettings(
+                PlayerSetup.participant(),
+                race,
+                null,
+                null,
+                null,
+                null);
+    }
+
     public PlayerSetup getPlayerSetup() {
         return playerSetup;
     }

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/syntax/SettingsSyntax.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/syntax/SettingsSyntax.java
@@ -26,6 +26,7 @@ package com.github.ocraft.s2client.bot.syntax;
  * #L%
  */
 
+import com.github.ocraft.s2client.protocol.game.MultiplayerOptions;
 import com.github.ocraft.s2client.protocol.game.ReplayInfo;
 import com.github.ocraft.s2client.protocol.spatial.SpatialCameraSetup;
 
@@ -228,4 +229,11 @@ public interface SettingsSyntax extends GameParticipantSyntax, ReplaySyntax {
      * The map_size and playable_area will be the diagonal of the real playable area.
      */
     SettingsSyntax setRawCropToPlayableArea(Boolean rawCropToPlayableArea);
+
+    /**
+     * Changes the multiplayer options for the coordinator. This allows you to specify the ports directly,
+     * for example if you are connecting to a multiplayer game.
+     * NOTE: Setting the MultiplayerOptions directly will supercede the any Ladder settings you provide.
+     */
+    SettingsSyntax setMultiplayerOptions(MultiplayerOptions multiplayerOptions);
 }

--- a/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleBot.java
+++ b/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleBot.java
@@ -34,9 +34,7 @@ import com.github.ocraft.s2client.protocol.data.Ability;
 import com.github.ocraft.s2client.protocol.data.UnitType;
 import com.github.ocraft.s2client.protocol.data.Units;
 import com.github.ocraft.s2client.protocol.debug.Color;
-import com.github.ocraft.s2client.protocol.game.BattlenetMap;
-import com.github.ocraft.s2client.protocol.game.Difficulty;
-import com.github.ocraft.s2client.protocol.game.Race;
+import com.github.ocraft.s2client.protocol.game.*;
 import com.github.ocraft.s2client.protocol.game.raw.StartRaw;
 import com.github.ocraft.s2client.protocol.response.ResponseGameInfo;
 import com.github.ocraft.s2client.protocol.spatial.Point2d;
@@ -277,14 +275,24 @@ public class SampleBot {
 
     static void runAsHost(String[] args) {
         TestBot bot = new TestBot();
+        // A clientPorts set must exist for each client, even though one of them is the server.
+        // Both agents must use the same MultiplayerOptions in their JoinGame requests.
+        MultiplayerOptions multiplayerOptions = MultiplayerOptions.multiplayerSetup()
+                .sharedPort(5000)
+                .serverPort(PortSet.of(5001, 5002))
+                .clientPorts(
+                        PortSet.of(5003, 5004),
+                        PortSet.of(5005, 5006))
+                .build();
+        // One agent must create and join the game. The other agent only needs to join the game.
         S2Coordinator s2Coordinator = S2Coordinator.setup()
                 .loadSettings(args)
                 .setTimeoutMS(120000)
+                .setMultiplayerOptions(multiplayerOptions)
                 .setParticipants(
                         S2Coordinator.createParticipant(Race.TERRAN, bot),
                         S2Coordinator.createParticipant(Race.TERRAN))
                 .launchStarcraft(4000)
-                .withPorts(2, () -> 5000, false)
                 .startGame(BattlenetMap.of("Lava Flow"));
 
         while (s2Coordinator.update()) {
@@ -295,14 +303,24 @@ public class SampleBot {
 
     static void runAsClient(String[] args) {
         TestBot bot = new TestBot();
+        // A clientPorts set must exist for each client, even though one of them is the server.
+        // Both agents must use the same MultiplayerOptions in their JoinGame requests.
+        MultiplayerOptions multiplayerOptions = MultiplayerOptions.multiplayerSetup()
+                .sharedPort(5000)
+                .serverPort(PortSet.of(5001, 5002))
+                .clientPorts(
+                        PortSet.of(5003, 5004),
+                        PortSet.of(5005, 5006))
+                .build();
+        // One agent must create and join the game. The other agent only needs to join the game.
         S2Coordinator s2Coordinator = S2Coordinator.setup()
                 .loadSettings(args)
                 .setTimeoutMS(120000)
+                .setMultiplayerOptions(multiplayerOptions)
                 .setParticipants(
                         S2Coordinator.createParticipant(Race.TERRAN, bot),
                         S2Coordinator.createParticipant(Race.TERRAN))
                 .launchStarcraft(4001)
-                .withPorts(2, () -> 5000, false)
                 .joinGame();
 
         while (s2Coordinator.update()) {

--- a/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleBot.java
+++ b/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleBot.java
@@ -275,4 +275,40 @@ public class SampleBot {
         s2Coordinator.quit();
     }
 
+    static void runAsHost(String[] args) {
+        TestBot bot = new TestBot();
+        S2Coordinator s2Coordinator = S2Coordinator.setup()
+                .loadSettings(args)
+                .setTimeoutMS(120000)
+                .setParticipants(
+                        S2Coordinator.createParticipant(Race.TERRAN, bot),
+                        S2Coordinator.createParticipant(Race.TERRAN))
+                .launchStarcraft(4000)
+                .withPorts(2, () -> 5000, false)
+                .startGame(BattlenetMap.of("Lava Flow"));
+
+        while (s2Coordinator.update()) {
+        }
+
+        s2Coordinator.quit();
+    }
+
+    static void runAsClient(String[] args) {
+        TestBot bot = new TestBot();
+        S2Coordinator s2Coordinator = S2Coordinator.setup()
+                .loadSettings(args)
+                .setTimeoutMS(120000)
+                .setParticipants(
+                        S2Coordinator.createParticipant(Race.TERRAN, bot),
+                        S2Coordinator.createParticipant(Race.TERRAN))
+                .launchStarcraft(4001)
+                .withPorts(2, () -> 5000, false)
+                .joinGame();
+
+        while (s2Coordinator.update()) {
+        }
+
+        s2Coordinator.quit();
+    }
+
 }

--- a/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleMultiplayerBotClient.java
+++ b/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleMultiplayerBotClient.java
@@ -1,8 +1,8 @@
-package com.github.ocraft.s2client.bot.syntax;
+package com.github.ocraft.s2client.sample;
 
 /*-
  * #%L
- * ocraft-s2client-bot
+ * ocraft-s2client-sample
  * %%
  * Copyright (C) 2017 - 2018 Ocraft Project
  * %%
@@ -12,10 +12,10 @@ package com.github.ocraft.s2client.bot.syntax;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,29 +26,11 @@ package com.github.ocraft.s2client.bot.syntax;
  * #L%
  */
 
-import com.github.ocraft.s2client.bot.S2Coordinator;
+// Running two bots in one game.
+public class SampleMultiplayerBotClient {
 
-public interface StartGameSyntax {
+    public static void main(String[] args) {
+        SampleBot.runAsClient(args);
+    }
 
-    /**
-     * Uses settings gathered from LoadSettings, specifically the path to the executable, to run StarCraft II.
-     * Uses the PortStart to select a port for the game to listen on.
-     */
-    S2Coordinator launchStarcraft();
-
-    /**
-     * Uses settings gathered from LoadSettings, specifically the path to the executable, to run StarCraft II.
-     * Starts the game listening on a specific port.
-     */
-    S2Coordinator launchStarcraft(Integer port);
-
-    /**
-     * Attaches to a running Starcraft.
-     */
-    S2Coordinator connect(String ip, Integer port);
-
-    /**
-     * Attaches to a ladder server;
-     */
-    S2Coordinator connectToLadder();
 }

--- a/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleMultiplayerBotHost.java
+++ b/ocraft-s2client-sample/src/main/java/com/github/ocraft/s2client/sample/SampleMultiplayerBotHost.java
@@ -1,8 +1,8 @@
-package com.github.ocraft.s2client.bot.syntax;
+package com.github.ocraft.s2client.sample;
 
 /*-
  * #%L
- * ocraft-s2client-bot
+ * ocraft-s2client-sample
  * %%
  * Copyright (C) 2017 - 2018 Ocraft Project
  * %%
@@ -12,10 +12,10 @@ package com.github.ocraft.s2client.bot.syntax;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,29 +26,11 @@ package com.github.ocraft.s2client.bot.syntax;
  * #L%
  */
 
-import com.github.ocraft.s2client.bot.S2Coordinator;
+// Running two bots in one game.
+public class SampleMultiplayerBotHost {
 
-public interface StartGameSyntax {
+    public static void main(String[] args) {
+        SampleBot.runAsHost(args);
+    }
 
-    /**
-     * Uses settings gathered from LoadSettings, specifically the path to the executable, to run StarCraft II.
-     * Uses the PortStart to select a port for the game to listen on.
-     */
-    S2Coordinator launchStarcraft();
-
-    /**
-     * Uses settings gathered from LoadSettings, specifically the path to the executable, to run StarCraft II.
-     * Starts the game listening on a specific port.
-     */
-    S2Coordinator launchStarcraft(Integer port);
-
-    /**
-     * Attaches to a running Starcraft.
-     */
-    S2Coordinator connect(String ip, Integer port);
-
-    /**
-     * Attaches to a ladder server;
-     */
-    S2Coordinator connectToLadder();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -523,9 +523,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.plugin.surefire}</version>
-                <configuration>
-                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
+        <maven.compiler.source>1.9</maven.compiler.source>
+        <maven.compiler.target>1.9</maven.compiler.target>
+
         <test.integration.skip>true</test.integration.skip>
         <test.integration.groups />
 
@@ -84,18 +87,18 @@
 
         <version.junit-platform>1.3.1</version.junit-platform>
         <version.junit-jupiter>5.3.1</version.junit-jupiter>
-        <version.mockito>4.8.1</version.mockito>
+        <version.mockito>3.3.3</version.mockito>
         <version.assertj>3.11.1</version.assertj>
-        <version.equalsverifier>3.10.1</version.equalsverifier>
+        <version.equalsverifier>3.0.2</version.equalsverifier>
         <version.objectdiff>0.95</version.objectdiff>
         <version.awaitility>1.7.0</version.awaitility>
 
         <version.plugin.surefire>2.22.0</version.plugin.surefire>
         <version.plugin.filesafe>2.22.0</version.plugin.filesafe>
-        <version.plugin.jacoco>0.8.8</version.plugin.jacoco>
+        <version.plugin.jacoco>0.8.2</version.plugin.jacoco>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>
         <version.plugin.build-helper>3.0.0</version.plugin.build-helper>
-        <version.plugin.compiler>3.10.1</version.plugin.compiler>
+        <version.plugin.compiler>3.8.0</version.plugin.compiler>
         <version.plugin.os>1.6.0</version.plugin.os>
         <version.plugin.jar>3.1.0</version.plugin.jar>
         <version.plugin.source>3.0.1</version.plugin.source>
@@ -515,19 +518,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.plugin.compiler}</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                    <release>17</release>
-                    <fork>true</fork>
-                    <executable>${JAVA_17_HOME}/bin/javac</executable>
-                    <compilerVersion>17</compilerVersion>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.plugin.surefire}</version>
+                <configuration>
+                    <argLine>-Xmx1024m</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <maven.compiler.source>1.9</maven.compiler.source>
-        <maven.compiler.target>1.9</maven.compiler.target>
-
         <test.integration.skip>true</test.integration.skip>
         <test.integration.groups />
 
@@ -87,18 +84,18 @@
 
         <version.junit-platform>1.3.1</version.junit-platform>
         <version.junit-jupiter>5.3.1</version.junit-jupiter>
-        <version.mockito>3.3.3</version.mockito>
+        <version.mockito>4.8.1</version.mockito>
         <version.assertj>3.11.1</version.assertj>
-        <version.equalsverifier>3.0.2</version.equalsverifier>
+        <version.equalsverifier>3.10.1</version.equalsverifier>
         <version.objectdiff>0.95</version.objectdiff>
         <version.awaitility>1.7.0</version.awaitility>
 
         <version.plugin.surefire>2.22.0</version.plugin.surefire>
         <version.plugin.filesafe>2.22.0</version.plugin.filesafe>
-        <version.plugin.jacoco>0.8.2</version.plugin.jacoco>
+        <version.plugin.jacoco>0.8.8</version.plugin.jacoco>
         <version.plugin.protobuf>0.5.1</version.plugin.protobuf>
         <version.plugin.build-helper>3.0.0</version.plugin.build-helper>
-        <version.plugin.compiler>3.8.0</version.plugin.compiler>
+        <version.plugin.compiler>3.10.1</version.plugin.compiler>
         <version.plugin.os>1.6.0</version.plugin.os>
         <version.plugin.jar>3.1.0</version.plugin.jar>
         <version.plugin.source>3.0.1</version.plugin.source>
@@ -518,6 +515,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.plugin.compiler}</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <release>17</release>
+                    <fork>true</fork>
+                    <executable>${JAVA_17_HOME}/bin/javac</executable>
+                    <compilerVersion>17</compilerVersion>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I was not able to get the bots to join a multiplayer game. I believe it was because the host was creating the game with only one participant, but there was no way to add another participant _that wasn't an agent in the same JVM_.

This way you can, say, run two bots in different JVMs.

Also added some additional API methods to make constructing games a bit nicer. 

Feel free to roll back the Java 17 upgrade, I only did that upgrade so it would actually build on my machine.