### PR TITLE
Bump protobuf dependency version to enable support for M1 Macbooks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <test.integration.skip>true</test.integration.skip>
         <test.integration.groups />
 
-        <version.protobuf>3.7.1</version.protobuf>
+        <version.protobuf>3.21.9</version.protobuf>
         <version.vertx>3.7.0</version.vertx>
         <version.javassist>3.23.1-GA</version.javassist>
         <version.slf4j>1.7.30</version.slf4j>


### PR DESCRIPTION
Protobuf 3.7.1 does not support MacOS M1 architecture, increasing the the latest protocol buffer release enables support for building this project on the newer mac models.

See protoc-jar issue https://github.com/os72/protoc-jar/issues/93