### PR TITLE
Request Response Syncrnization across threads and Replay/Observer updates

### DIFF
--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
@@ -210,12 +210,12 @@ public class S2Controller extends DefaultSubscriber<Response> {
         log.info("Launching Starcraft II with configuration: {}.", cfg);
         try {
             Path gameRoot = Paths.get(cfg.getString(GAME_EXE_ROOT));
-            String exeFile = gameRoot
+            String exeFile = cfg.getString(GAME_EXE_PATH);/*gameRoot
                     .resolve(Paths.get(
                             ExecutableParser.VERSIONS_DIR,
                             cfg.getString(GAME_EXE_BUILD),
                             cfg.getString(GAME_EXE_FILE)))
-                    .toString();
+                    .toString();*/
 
             List<String> args = new ArrayList<>();
             args.add(exeFile);

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2Coordinator.java
@@ -828,7 +828,7 @@ public class S2Coordinator {
                 }
                 if (shouldRelaunch(replayObserver)) break;
                 boolean launched = !replayObserver.replayControl()
-                        .loadReplay(replay, interfaceSettings, 1, processSettings.getRealtime())
+                        .loadReplay(replay, interfaceSettings, 0, processSettings.getRealtime())
                         .isEmpty()
                         .blockingGet();
                 replays.remove(replays.size() - 1);

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2ReplayObserver.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/S2ReplayObserver.java
@@ -60,7 +60,7 @@ public class S2ReplayObserver extends Client {
      * @param replayInfo Replay information used to decide if the replay should be filtered.
      * @return If 'true', the replay will be rejected and not analyzed.
      */
-    boolean ignoreReplay(ReplayInfo replayInfo, int playerId) {
+    public boolean ignoreReplay(ReplayInfo replayInfo, int playerId) {
         return replayInfo.getGameDurationSeconds() < MINIMUM_REPLAY_DURATION;
     }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
@@ -26,7 +26,9 @@ package com.github.ocraft.s2client.bot.gateway;
  * #L%
  */
 
-import com.github.ocraft.s2client.protocol.spatial.PointI;
+import com.github.ocraft.s2client.protocol.spatial.Point2d;
+import com.github.ocraft.s2client.protocol.unit.Tag;
+import com.github.ocraft.s2client.protocol.unit.Unit;
 
 /**
  * The ObserverActionInterface corresponds to the actions available in the observer UI.
@@ -40,7 +42,7 @@ public interface ObserverActionInterface {
      * @param distance Distance between camera and terrain. Larger value zooms out camera. Defaults to standard camera
      *                 distance if set to 0.
      */
-    ObserverActionInterface cameraMove(PointI point, float distance);
+    ObserverActionInterface cameraMove(Point2d point, float distance);
 
     /**
      * Makes the observer camera follow the observed player's perspective.
@@ -48,6 +50,12 @@ public interface ObserverActionInterface {
      * @param playerId Player to follow.
      */
     ObserverActionInterface cameraFollowPlayer(int playerId);
+
+    ObserverActionInterface cameraSetPerspective(int playerId);
+
+    ObserverActionInterface cameraFollowUnits(Unit...unit, float distance);
+
+    ObserverActionInterface cameraFollowUnits(Tag...unit, float distance);
 
     /**
      * This function sends out all batched commands. You DO NOT need to call this function.

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
@@ -51,11 +51,26 @@ public interface ObserverActionInterface {
      */
     ObserverActionInterface cameraFollowPlayer(int playerId);
 
+    /**
+     * Makes the observer view the camera from the perspective of a player
+     *
+     * @param playerId Player to use perspective of.
+     */
     ObserverActionInterface cameraSetPerspective(int playerId);
 
-    ObserverActionInterface cameraFollowUnits(Unit...unit, float distance);
+    /**
+     * Moves the observer to follow the specific set of units.
+     *
+     * @param units The units to follow.
+     */
+    ObserverActionInterface cameraFollowUnits(Unit...units);
 
-    ObserverActionInterface cameraFollowUnits(Tag...unit, float distance);
+    /**
+     * Moves the observer camera to follow a specific set of units.
+     *
+     * @param units The units to follow.
+     */
+    ObserverActionInterface cameraFollowUnits(Tag...units);
 
     /**
      * This function sends out all batched commands. You DO NOT need to call this function.

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
@@ -26,7 +26,7 @@ package com.github.ocraft.s2client.bot.gateway;
  * #L%
  */
 
-import com.github.ocraft.s2client.protocol.spatial.Point2d;
+import com.github.ocraft.s2client.protocol.spatial.Point2I;
 import com.github.ocraft.s2client.protocol.unit.Tag;
 import com.github.ocraft.s2client.protocol.unit.Unit;
 
@@ -42,7 +42,7 @@ public interface ObserverActionInterface {
      * @param distance Distance between camera and terrain. Larger value zooms out camera. Defaults to standard camera
      *                 distance if set to 0.
      */
-    ObserverActionInterface cameraMove(Point2d point, float distance);
+    ObserverActionInterface cameraMove(Point2I point, float distance);
 
     /**
      * Makes the observer camera follow the observed player's perspective.

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/ObserverActionInterface.java
@@ -26,7 +26,7 @@ package com.github.ocraft.s2client.bot.gateway;
  * #L%
  */
 
-import com.github.ocraft.s2client.protocol.spatial.Point2I;
+import com.github.ocraft.s2client.protocol.spatial.Point2d;
 import com.github.ocraft.s2client.protocol.unit.Tag;
 import com.github.ocraft.s2client.protocol.unit.Unit;
 
@@ -42,7 +42,7 @@ public interface ObserverActionInterface {
      * @param distance Distance between camera and terrain. Larger value zooms out camera. Defaults to standard camera
      *                 distance if set to 0.
      */
-    ObserverActionInterface cameraMove(Point2I point, float distance);
+    ObserverActionInterface cameraMove(Point2d point, float distance);
 
     /**
      * Makes the observer camera follow the observed player's perspective.

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -75,7 +75,7 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
 
     @Override
     public ObserverActionInterface cameraSetPerspective(int playerId) {
-        actions.add(ActionObserverPlayerPerspective.playerPerspective().ofPlayer(playerId));
+        actions.add(ObserverAction.observerAction().of(ActionObserverPlayerPerspective.playerPerspective().ofPlayer(playerId)));
         return this;
     }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -39,7 +39,6 @@ import com.github.ocraft.s2client.protocol.action.observer.ActionObserverPlayerP
 import com.github.ocraft.s2client.protocol.action.observer.ActionObserverCameraFollowUnits;
 import com.github.ocraft.s2client.protocol.unit.Tag;
 import com.github.ocraft.s2client.protocol.unit.Unit;
-import com.github.ocraft.s2client.protocol.spatial.Point2I;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +57,7 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
     }
 
     @Override
-    public ObserverActionInterface cameraMove(Point2I point, float distance) {
+    public ObserverActionInterface cameraMove(Point2d point, float distance) {
         actions.add(ObserverAction.observerAction().of(
                 ActionObserverCameraMove
                         .cameraMove()

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -35,7 +35,8 @@ import com.github.ocraft.s2client.protocol.request.RequestObserverAction;
 import com.github.ocraft.s2client.protocol.request.Requests;
 import com.github.ocraft.s2client.protocol.response.ResponseObserverAction;
 import com.github.ocraft.s2client.protocol.spatial.Point2d;
-import com.github.ocraft.s2client.protocol.spatial.PointI;
+import com.github.ocraft.s2client.protocol.action.observer.ActionObserverPlayerPerspective;
+import com.github.ocraft.s2client.protocol.action.observer.ActionObserverCameraFollowUnits;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
     }
 
     @Override
-    public ObserverActionInterface cameraMove(PointI point, float distance) {
+    public ObserverActionInterface cameraMove(Point2d point, float distance) {
         actions.add(ObserverAction.observerAction().of(
                 ActionObserverCameraMove
                         .cameraMove()
@@ -67,6 +68,24 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
     public ObserverActionInterface cameraFollowPlayer(int playerId) {
         actions.add(ObserverAction.observerAction().of(
                 ActionObserverCameraFollowPlayer.cameraFollowPlayer().withId(playerId)));
+        return this;
+    }
+
+    @Override
+    public ObserverActionInterface cameraSetPerspective(int playerId) {
+        actions.add(ActionObserverPlayerPerspective.playerPerspective().ofPlayer(playerId));
+        return this;
+    }
+
+    @Override
+    public ObserverActionInterface cameraFollowUnits(Unit...units) {
+        actions.add(ActionObserverCameraFollowUnits.cameraFollowUnits().of(units));
+        return this;
+    }
+
+    @Override
+    public ObserverActionInterface cameraFollowUnits(Tag...units) {
+        actions.add(ActionObserverCameraFollowUnits.cameraFollowUnits().withTags(units));
         return this;
     }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -81,13 +81,13 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
 
     @Override
     public ObserverActionInterface cameraFollowUnits(Unit...units) {
-        actions.add(ActionObserverCameraFollowUnits.cameraFollowUnits().of(units));
+        actions.add(ObserverAction.observerAction().of(ActionObserverCameraFollowUnits.cameraFollowUnits().of(units)));
         return this;
     }
 
     @Override
     public ObserverActionInterface cameraFollowUnits(Tag...units) {
-        actions.add(ActionObserverCameraFollowUnits.cameraFollowUnits().withTags(units));
+        actions.add(ObserverAction.observerAction().of(ActionObserverCameraFollowUnits.cameraFollowUnits().withTags(units)));
         return this;
     }
 

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -39,6 +39,7 @@ import com.github.ocraft.s2client.protocol.action.observer.ActionObserverPlayerP
 import com.github.ocraft.s2client.protocol.action.observer.ActionObserverCameraFollowUnits;
 import com.github.ocraft.s2client.protocol.unit.Tag;
 import com.github.ocraft.s2client.protocol.unit.Unit;
+import com.github.ocraft.s2client.protocol.spatial.Point2I;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +58,7 @@ class ObserverActionInterfaceImpl implements ObserverActionInterface {
     }
 
     @Override
-    public ObserverActionInterface cameraMove(Point2d point, float distance) {
+    public ObserverActionInterface cameraMove(Point2I point, float distance) {
         actions.add(ObserverAction.observerAction().of(
                 ActionObserverCameraMove
                         .cameraMove()

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImpl.java
@@ -37,6 +37,8 @@ import com.github.ocraft.s2client.protocol.response.ResponseObserverAction;
 import com.github.ocraft.s2client.protocol.spatial.Point2d;
 import com.github.ocraft.s2client.protocol.action.observer.ActionObserverPlayerPerspective;
 import com.github.ocraft.s2client.protocol.action.observer.ActionObserverCameraFollowUnits;
+import com.github.ocraft.s2client.protocol.unit.Tag;
+import com.github.ocraft.s2client.protocol.unit.Unit;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
@@ -129,14 +129,15 @@ class ProtoInterfaceImpl implements ProtoInterface {
     @Override
     public <T extends Request> Maybe<Response> sendRequest(T requestData) {
         require("request", requestData);
-        // TODO testing removing this validation
-        /*if (!requestData.responseType().equals(ResponseType.PING) &&
-                responseQueue.peek(requestData.responseType())) {
-            // TODO p.picheta to test
-            onError.accept(ClientError.RESPONSE_NOT_CONSUMED, Collections.emptyList());
-            return Maybe.empty();
-        }*/
-        Maybe<Response> responseMaybe = s2Client.waitForResponse(requestData.responseType());
+        Maybe<Response> responseMaybe;
+        if (!requestData.responseType().equals(ResponseType.PING) && responseQueue.peek(requestData.responseType())) {
+            // We don't need to sync when using a ping response type
+            synchronized(requestData.responseType()) {
+                responseMaybe = s2Client.waitForResponse(requestData.responseType());
+            }
+        } else {
+            responseMaybe = s2Client.waitForResponse(requestData.responseType());
+        }
         s2Client.request(requestData);
         countUses.compute(requestData.responseType(), (responseType, count) -> count != null ? ++count : 1);
         responseQueue.offer(requestData.responseType(), responseMaybe);

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ProtoInterfaceImpl.java
@@ -129,12 +129,13 @@ class ProtoInterfaceImpl implements ProtoInterface {
     @Override
     public <T extends Request> Maybe<Response> sendRequest(T requestData) {
         require("request", requestData);
-        if (!requestData.responseType().equals(ResponseType.PING) &&
+        // TODO testing removing this validation
+        /*if (!requestData.responseType().equals(ResponseType.PING) &&
                 responseQueue.peek(requestData.responseType())) {
             // TODO p.picheta to test
             onError.accept(ClientError.RESPONSE_NOT_CONSUMED, Collections.emptyList());
             return Maybe.empty();
-        }
+        }*/
         Maybe<Response> responseMaybe = s2Client.waitForResponse(requestData.responseType());
         s2Client.request(requestData);
         countUses.compute(requestData.responseType(), (responseType, count) -> count != null ? ++count : 1);

--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/QueryInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/QueryInterfaceImpl.java
@@ -77,8 +77,6 @@ class QueryInterfaceImpl implements QueryInterface {
                 .orElseGet(ArrayList::new);
 
         // TODO p.picheta to test
-        control().errorIf(availableAbilities.isEmpty(), ClientError.NO_ABILITIES_FOR_TAG, Collections.emptyList());
-
         if (control().isUseGeneralizedAbilityId()) {
             availableAbilities = availableAbilities.stream()
                     .map(ability -> ability.generalizeAbility(control().observationInternal()::getGeneralizedAbility))

--- a/ocraft-s2client-bot/src/test/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImplIT.java
+++ b/ocraft-s2client-bot/src/test/java/com/github/ocraft/s2client/bot/gateway/impl/ObserverActionInterfaceImplIT.java
@@ -29,7 +29,7 @@ package com.github.ocraft.s2client.bot.gateway.impl;
 import SC2APIProtocol.Sc2Api;
 import com.github.ocraft.s2client.bot.GameServerResponses;
 import com.github.ocraft.s2client.bot.gateway.ObserverActionInterface;
-import com.github.ocraft.s2client.protocol.spatial.PointI;
+import com.github.ocraft.s2client.protocol.spatial.Point2d;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +43,7 @@ class ObserverActionInterfaceImplIT {
         gameSetup.server().onRequest(Sc2Api.Request::hasObsAction, GameServerResponses::obsAction);
 
         ObserverActionInterface observerAction = gameSetup.control().observerAction();
-        observerAction.cameraMove(PointI.of(1, 2), 1.0f).cameraFollowPlayer(1);
+        observerAction.cameraMove(Point2d.of(1, 2), 1.0f).cameraFollowPlayer(1);
 
         assertThat(observerAction.sendActions()).as("sending observer action status").isTrue();
         assertThat(observerAction.sendActions()).as("sending empty observer action status").isFalse();


### PR DESCRIPTION
This updates the Query calls to allow multiple requests of the same type by syncronizing them across multiple threads instead of just erroring out.

I then got distracted by Replay and Observer things and adjusted the library so that it is actually able to do everything or nearly everything that the C++ AutoObserver library is able to do.