### PR TITLE
fix: sc2 version is no longer hardcoded to most recent version

### DIFF
--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/ExecutableParser.java
@@ -73,11 +73,7 @@ public final class ExecutableParser {
         try {
             Map<String, Object> executableConfig = new HashMap<>();
 
-            if (customPath == null) {
-                executableConfig.put(GAME_EXE_PATH, findExecutablePath().toString());
-            } else {
-                executableConfig.put(GAME_EXE_PATH, customPath);
-            }
+            executableConfig.put(GAME_EXE_PATH, customPath == null ? findExecutablePath().toString() : customPath);
 
             Path executablePath = Paths.get((String) executableConfig.get(GAME_EXE_PATH));
 
@@ -106,7 +102,7 @@ public final class ExecutableParser {
             String baseBuild = customBaseBuild;
 
             if (!isSet(baseBuild)) {
-                baseBuild = toNewestBaseBuild(exeFile).apply(gamePath.resolve(VERSIONS_DIR));
+                baseBuild = getBaseBuildFromGameExePath((String) executableConfig.get(GAME_EXE_PATH));
             }
 
             executableConfig.put(GAME_EXE_BUILD, baseBuild);
@@ -124,6 +120,16 @@ public final class ExecutableParser {
             throw new StarCraft2ControllerException(
                     ControllerError.INVALID_EXECUTABLE, "Invalid argument was provided", e);
         }
+    }
+
+    private static String getBaseBuildFromGameExePath(String gameExePath) {
+        String[] dirTree = gameExePath.split("\\\\");
+        for (String dir : dirTree) {
+            if (dir.startsWith("Base")) {
+                return dir;
+            }
+        }
+        return null;
     }
 
     private static Path findExecutablePath() {

--- a/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
+++ b/ocraft-s2client-api/src/main/java/com/github/ocraft/s2client/api/controller/S2Controller.java
@@ -210,12 +210,7 @@ public class S2Controller extends DefaultSubscriber<Response> {
         log.info("Launching Starcraft II with configuration: {}.", cfg);
         try {
             Path gameRoot = Paths.get(cfg.getString(GAME_EXE_ROOT));
-            String exeFile = gameRoot
-                    .resolve(Paths.get(
-                            ExecutableParser.VERSIONS_DIR,
-                            cfg.getString(GAME_EXE_BUILD),
-                            cfg.getString(GAME_EXE_FILE)))
-                    .toString();
+            String exeFile = cfg.getString(GAME_EXE_PATH);
 
             List<String> args = new ArrayList<>();
             args.add(exeFile);

--- a/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/Fixtures.java
+++ b/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/Fixtures.java
@@ -65,7 +65,7 @@ public class Fixtures {
     public static final int CFG_NET_PORT = 5000;
     public static final String CFG_EXE_BUILD_NEW = "Base58400";
     public static final String CFG_EXE_BUILD_OLD = "Base55958";
-    public static final String CFG_EXE_DATA_VER = "2B06AEE58017A7DF2A3D452D733F1019";
+    public static final String CFG_EXE_DATA_VER = "5BD7C31B44525DAB46E64C4602A81DC2";
     public static final String GAME_DIR = "Starcraft II";
     public static final int CFG_WINDOW_W = 1024;
     public static final int CFG_WINDOW_H = 768;

--- a/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/controller/S2ControllerTest.java
+++ b/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/controller/S2ControllerTest.java
@@ -93,7 +93,7 @@ class S2ControllerTest {
                 entry(GAME_NET_RETRY_COUNT, 10),
                 entry(GAME_EXE_ROOT, gameRoot.toString()),
                 entry(GAME_EXE_PATH, exePath),
-                entry(GAME_EXE_BUILD, CFG_EXE_BUILD_NEW),
+                entry(GAME_EXE_BUILD, CFG_EXE_BUILD_OLD),
                 entry(GAME_EXE_FILE, CFG_EXE_FILE),
                 entry(GAME_EXE_DATA_VER, CFG_EXE_DATA_VER),
                 entry(GAME_EXE_IS_64, true),


### PR DESCRIPTION
This change uses GAME_EXE_PATH config value, which is set by first checking for the author's inputted path from setProcessPath() method or "-e=<processPath>" command line argument.  If neither is set then it defaults to path of the latest version of sc2 otherwise.