### PR TITLE
Add Neutral and Ally units to issueUnitAddedEvents()

### DIFF
--- a/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
+++ b/ocraft-s2client-bot/src/main/java/com/github/ocraft/s2client/bot/gateway/impl/ControlInterfaceImpl.java
@@ -666,9 +666,9 @@ class ControlInterfaceImpl implements ControlInterface {
     private void issueUnitAddedEvents() {
         observationInternal().unitPool().forEachExistingUnit(unitInPool -> unitInPool.getUnit().ifPresent(unit -> {
             if (!hasPreviousState(unit)) {
-                if (unit.getAlliance().equals(Alliance.ENEMY) && unit.getDisplayType().equals(DisplayType.VISIBLE)) {
+                if ((unit.getAlliance().equals(Alliance.ENEMY) || unit.getAlliance().equals(Alliance.NEUTRAL)) && unit.getDisplayType().equals(DisplayType.VISIBLE)) {
                     clientEvents.onUnitEnterVision(unitInPool);
-                } else if (unit.getAlliance().equals(Alliance.SELF) && !calledOnCreateUnits.contains(unit.getTag())) {
+                } else if ((unit.getAlliance().equals(Alliance.SELF) || unit.getAlliance().equals(Alliance.ALLY)) && !calledOnCreateUnits.contains(unit.getTag())) {
                     calledOnCreateUnits.add(unit.getTag());
                     clientEvents.onUnitCreated(unitInPool);
                 }


### PR DESCRIPTION
This is most of the adjustment for #80 but with nothing for units that are added but in the fog as I agree with Ketroc that they should not be added to the onUnitEnterVision call, 

Some things we may want to add is:
- Another method call for units that are added but are in the fog of war.
- Self units that "onUnitEnterVision " for example when they are unloaded or leave a gas structure for easier handling of these cases