### PR TITLE
fix: Difficulty naming convention corrected for BlizzAI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ sc2client-api should be valid or similar by analogy in this Java Api. More info 
 <dependency>
     <groupId>com.github.ocraft</groupId>
     <artifactId>ocraft-s2client-bot</artifactId>
-    <version>0.4.21</version>
+    <version>0.4.23</version>
 </dependency>
 ----
 

--- a/docs/building.adoc
+++ b/docs/building.adoc
@@ -13,7 +13,7 @@ For reference, it can be found here: https://github.com/ocraft/ocraft-s2client
 <dependency>
     <groupId>com.github.ocraft</groupId>
     <artifactId>ocraft-s2client-bot</artifactId>
-    <version>0.4.21</version>
+    <version>0.4.23</version>
 </dependency>
 ----
 . If you want to build your own version (you need maven install on your PATH):

--- a/ocraft-s2client-api/README.adoc
+++ b/ocraft-s2client-api/README.adoc
@@ -19,7 +19,7 @@ analyze in many different tools.
 <dependency>
     <groupId>com.github.ocraft</groupId>
     <artifactId>ocraft-s2client-api</artifactId>
-    <version>0.4.21</version>
+    <version>0.4.23</version>
 </dependency>
 ----
 

--- a/ocraft-s2client-api/pom.xml
+++ b/ocraft-s2client-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/OcraftS2ClientEndToEndIT.java
+++ b/ocraft-s2client-api/src/test/java/com/github/ocraft/s2client/api/OcraftS2ClientEndToEndIT.java
@@ -338,7 +338,7 @@ class OcraftS2ClientEndToEndIT {
     private void startTheGameAsObserver() {
         client.request(createGame()
                 .onLocalMap(LocalMap.of(MAP_PATH))
-                .withPlayerSetup(observer(), computer(TERRAN, Difficulty.HARD))
+                .withPlayerSetup(observer(), computer(TERRAN, Difficulty.HARDER))
                 .disableFog());
         subscriber.hasReceivedResponseOfType(ResponseCreateGame.class);
         game.isInState(GameStatus.INIT_GAME);

--- a/ocraft-s2client-benchmark/pom.xml
+++ b/ocraft-s2client-benchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ocraft-s2client-bot/pom.xml
+++ b/ocraft-s2client-bot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ocraft-s2client-protocol/pom.xml
+++ b/ocraft-s2client-protocol/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ocraft-s2client-protocol/src/main/java/com/github/ocraft/s2client/protocol/game/Difficulty.java
+++ b/ocraft-s2client-protocol/src/main/java/com/github/ocraft/s2client/protocol/game/Difficulty.java
@@ -35,10 +35,10 @@ public enum Difficulty implements Sc2ApiSerializable<Sc2Api.Difficulty> {
     VERY_EASY,
     EASY,
     MEDIUM,
-    MEDIUM_HARD,
     HARD,
     HARDER,
     VERY_HARD,
+    ELITE,
     CHEAT_VISION,
     CHEAT_MONEY,
     CHEAT_INSANE;
@@ -52,14 +52,14 @@ public enum Difficulty implements Sc2ApiSerializable<Sc2Api.Difficulty> {
                 return Sc2Api.Difficulty.Easy;
             case MEDIUM:
                 return Sc2Api.Difficulty.Medium;
-            case MEDIUM_HARD:
-                return Sc2Api.Difficulty.MediumHard;
             case HARD:
                 return Sc2Api.Difficulty.Hard;
             case HARDER:
                 return Sc2Api.Difficulty.Harder;
             case VERY_HARD:
                 return Sc2Api.Difficulty.VeryHard;
+            case ELITE:
+                return Sc2Api.Difficulty.Elite;
             case CHEAT_VISION:
                 return Sc2Api.Difficulty.CheatVision;
             case CHEAT_MONEY:
@@ -80,14 +80,14 @@ public enum Difficulty implements Sc2ApiSerializable<Sc2Api.Difficulty> {
                 return EASY;
             case Medium:
                 return MEDIUM;
-            case MediumHard:
-                return MEDIUM_HARD;
             case Hard:
                 return HARD;
             case Harder:
                 return HARDER;
             case VeryHard:
                 return VERY_HARD;
+            case Elite:
+                return ELITE;
             case CheatVision:
                 return CHEAT_VISION;
             case CheatMoney:

--- a/ocraft-s2client-protocol/src/main/proto/s2clientprotocol/sc2api.proto
+++ b/ocraft-s2client-protocol/src/main/proto/s2clientprotocol/sc2api.proto
@@ -517,10 +517,10 @@ enum Difficulty {
   VeryEasy = 1;
   Easy = 2;
   Medium = 3;
-  MediumHard = 4;
-  Hard = 5;
-  Harder = 6;
-  VeryHard = 7;
+  Hard = 4;
+  Harder = 5;
+  VeryHard = 6;
+  Elite = 7;
   CheatVision = 8;
   CheatMoney = 9;
   CheatInsane = 10;

--- a/ocraft-s2client-protocol/src/test/java/com/github/ocraft/s2client/protocol/game/DifficultyTest.java
+++ b/ocraft-s2client-protocol/src/test/java/com/github/ocraft/s2client/protocol/game/DifficultyTest.java
@@ -52,10 +52,10 @@ class DifficultyTest {
                 Arguments.of(Difficulty.VERY_EASY, Sc2Api.Difficulty.VeryEasy),
                 Arguments.of(Difficulty.EASY, Sc2Api.Difficulty.Easy),
                 Arguments.of(Difficulty.MEDIUM, Sc2Api.Difficulty.Medium),
-                Arguments.of(Difficulty.MEDIUM_HARD, Sc2Api.Difficulty.MediumHard),
                 Arguments.of(Difficulty.HARD, Sc2Api.Difficulty.Hard),
                 Arguments.of(Difficulty.HARDER, Sc2Api.Difficulty.Harder),
                 Arguments.of(Difficulty.VERY_HARD, Sc2Api.Difficulty.VeryHard),
+                Arguments.of(Difficulty.ELITE, Sc2Api.Difficulty.Elite),
                 Arguments.of(Difficulty.CHEAT_VISION, Sc2Api.Difficulty.CheatVision),
                 Arguments.of(Difficulty.CHEAT_MONEY, Sc2Api.Difficulty.CheatMoney),
                 Arguments.of(Difficulty.CHEAT_INSANE, Sc2Api.Difficulty.CheatInsane)

--- a/ocraft-s2client-sample/pom.xml
+++ b/ocraft-s2client-sample/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ocraft-s2client-test/pom.xml
+++ b/ocraft-s2client-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>ocraft-s2client</artifactId>
         <groupId>com.github.ocraft</groupId>
-        <version>0.4.22-SNAPSHOT</version>
+        <version>0.4.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.github.ocraft</groupId>
     <artifactId>ocraft-s2client</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.22-SNAPSHOT</version>
+    <version>0.4.23-SNAPSHOT</version>
 
     <modules>
         <module>ocraft-s2client-test</module>


### PR DESCRIPTION
-new naming matches actual game, map editor, and other sc2ai frameworks
-increase patch version # from 0.4.22 to 0.4.23